### PR TITLE
ProfileCreator moves to its own GitHub account

### DIFF
--- a/Erik Burgland/ProfileCreator.download.recipe
+++ b/Erik Burgland/ProfileCreator.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>GITHUB_REPO</key>
-		<string>erikberglund/ProfileCreator</string>
+		<string>ProfileCreator/ProfileCreator</string>
 		<key>NAME</key>
 		<string>ProfileCreator</string>
 	</dict>


### PR DESCRIPTION
It appears that erikberglund moved ProfileCreator off of his Github account to a dedicated one for the project. Pointing to the new repo fixes the .download recipe.