### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Adobe/AdobeExpiryCheck.pkg.recipe
+++ b/Adobe/AdobeExpiryCheck.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
 					<key>version</key>

--- a/Adobe/AdobeUninstallUnauthorizedVersions.pkg.recipe
+++ b/Adobe/AdobeUninstallUnauthorizedVersions.pkg.recipe
@@ -58,10 +58,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
 					<key>version</key>

--- a/Astute/Astute Manager.pkg.recipe
+++ b/Astute/Astute Manager.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Belight Software/LabelsandAddresses.pkg.recipe
+++ b/Belight Software/LabelsandAddresses.pkg.recipe
@@ -75,9 +75,9 @@
                     <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                 </dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
             </dict>
             <key>Processor</key>
             <string>PkgCreator</string>

--- a/LAPS-for-macOS/LAPS-for-macOS.pkg.recipe
+++ b/LAPS-for-macOS/LAPS-for-macOS.pkg.recipe
@@ -45,10 +45,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Mozilla/FirefoxPolicies.pkg.recipe
+++ b/Mozilla/FirefoxPolicies.pkg.recipe
@@ -111,9 +111,9 @@ so you may need to verify that any particular combination is offered.</string>
                     <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
+                    <key>pkgname</key>
+                    <string>%NAME%_%ORG_NAME%-%version%</string>
                 </dict>
-                <key>pkgname</key>
-                <string>%NAME%_%ORG_NAME%-%version%</string>
             </dict>
             <key>Processor</key>
             <string>PkgCreator</string>

--- a/Native Instruments/NativeAccess.pkg.recipe
+++ b/Native Instruments/NativeAccess.pkg.recipe
@@ -49,10 +49,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%_%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%_%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Zotero/Zotero.pkg.recipe
+++ b/Zotero/Zotero.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%_%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%_%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).