### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Andrew Belt/VCV Rack.pkg.recipe
+++ b/Andrew Belt/VCV Rack.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.neilmartin83.pkg.VCVRack</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.vcvrack.rack</string>
 		<key>NAME</key>
 		<string>VCV_Rack</string>
 	</dict>

--- a/Buttplug/intiface-desktop.pkg.recipe
+++ b/Buttplug/intiface-desktop.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.neilmartin83.pkg.intiface-desktop</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.nonpolynomiallabs.intiface-desktop</string>
 		<key>NAME</key>
 		<string>intiface-desktop</string>
 	</dict>

--- a/Erik Burgland/ProfileCreator.pkg.recipe
+++ b/Erik Burgland/ProfileCreator.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.neilmartin83.pkg.ProfileCreator</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.github.erikberglund.ProfileCreator</string>
 		<key>NAME</key>
 		<string>ProfileCreator</string>
 	</dict>
@@ -19,14 +17,14 @@
 	<string>com.github.neilmartin83.download.ProfileCreator</string>
 	<key>Process</key>
 	<array>
-    		<dict>
-			<key>Processor</key>
-    			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>split_on</key>
 				<string>-beta</string>
 			</dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Frederik Berlaen/DrawBot.pkg.recipe
+++ b/Frederik Berlaen/DrawBot.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.neilmartin83.pkg.DrawBot</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.drawbot</string>
 		<key>NAME</key>
 		<string>DrawBot</string>
 	</dict>

--- a/Hasselblad/Phocus.pkg.recipe
+++ b/Hasselblad/Phocus.pkg.recipe
@@ -2,27 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads the latest version of Phocus and creates a package.</string>
-    <key>Identifier</key>
-    <string>com.github.neilmartin83.pkg.Phocus</string>
-    <key>Input</key>
-    <dict>
-        <key>BUNDLE_ID</key>
-        <string>dk.hasselblad.phocus</string>
-        <key>NAME</key>
-        <string>Phocus</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>1.0.0</string>
-    <key>ParentRecipe</key>
-    <string>com.github.neilmartin83.download.Phocus</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>AppPkgCreator</string>
-        </dict>
-    </array>
+	<key>Description</key>
+	<string>Downloads the latest version of Phocus and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.neilmartin83.pkg.Phocus</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Phocus</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.neilmartin83.download.Phocus</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Mounty for NTFS/Mounty.pkg.recipe
+++ b/Mounty for NTFS/Mounty.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.neilmartin83.pkg.Mounty</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.mounty</string>
 		<key>NAME</key>
 		<string>Mounty</string>
 	</dict>

--- a/Native Instruments/NativeAccess.pkg.recipe
+++ b/Native Instruments/NativeAccess.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.neilmartin83.pkg.NativeAccess</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.native-instruments.nativeaccess</string>
 		<key>NAME</key>
 		<string>Native_Instruments_Native_Access</string>
 	</dict>
@@ -20,61 +18,61 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict>
+					<key>Applications</key>
+					<string>0775</string>
+				</dict>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+			</dict>
 			<key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-            </dict>
+			<string>PkgRootCreator</string>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%pathname%/Native Access.app</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/Native Access.app</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgname</key>
-                <string>%NAME%_%version%</string>
-                <key>pkg_request</key>
-                <dict>
-                    <key>pkgdir</key>
-                    <string>%RECIPE_CACHE_DIR%</string>
-                    <key>id</key>
-                    <string>com.native-instruments.nativeaccess.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>scripts</key>
-                    <string>NativeAccess_Scripts</string>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
-                        </dict>
-                    </array>
-                </dict>
-            </dict>
-        </dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%pkgroot%/Applications/Native Access.app</string>
+				<key>source_path</key>
+				<string>%pathname%/Native Access.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_request</key>
+				<dict>
+					<key>chown</key>
+					<array>
+						<dict>
+							<key>group</key>
+							<string>admin</string>
+							<key>path</key>
+							<string>Applications</string>
+							<key>user</key>
+							<string>root</string>
+						</dict>
+					</array>
+					<key>id</key>
+					<string>com.native-instruments.nativeaccess.pkg</string>
+					<key>options</key>
+					<string>purge_ds_store</string>
+					<key>pkgdir</key>
+					<string>%RECIPE_CACHE_DIR%</string>
+					<key>scripts</key>
+					<string>NativeAccess_Scripts</string>
+				</dict>
+				<key>pkgname</key>
+				<string>%NAME%_%version%</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCreator</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Andrew Belt/VCV Rack.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/neilmartin83-recipes/Andrew\ Belt/VCV\ Rack.pkg.recipe
Processing repos/neilmartin83-recipes/Andrew Belt/VCV Rack.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(\\/Rack-\\S*-mac\\.zip)',
           'url': 'https://vcvrack.com/Rack.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): /Rack-1.1.6-mac.zip
{'Output': {'match': '/Rack-1.1.6-mac.zip'}}
URLDownloader
{'Input': {'filename': 'VCV_Rack.tgz',
           'url': 'https://vcvrack.com/downloads/Rack-1.1.6-mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/downloads/VCV_Rack.tgz
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/downloads/VCV_Rack.tgz'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/downloads/VCV_Rack.tgz',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/VCV_Rack',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'tar_gzip' from filename VCV_Rack.tgz
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/downloads/VCV_Rack.tgz to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/VCV_Rack
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/VCV_Rack/Rack.app',
           'requirement': 'identifier "com.vcvrack.rack" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'VRF26934X5'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/VCV_Rack/Rack.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/VCV_Rack/Rack.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/VCV_Rack/Rack.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/VCV_Rack/Rack.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 1.1.6 in file ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/VCV_Rack/Rack.app/Contents/Info.plist
{'Output': {'version': '1.1.6'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/VCV_Rack/Rack.app',
           'version': '1.1.6'}}
AppPkgCreator: BundleID: com.vcvrack.rack
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/VCV_Rack/Rack.app to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/payload/Applications/Rack.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.vcvrack.rack',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/Rack-1.1.6.pkg',
                                                        'version': '1.1.6'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.1.6'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/receipts/VCV Rack.pkg-receipt-20210213-231219.plist

The following packages were built:
    Identifier        Version  Pkg Path                                                                                 
    ----------        -------  --------                                                                                 
    com.vcvrack.rack  1.1.6    ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.VCVRack/Rack-1.1.6.pkg  
```

## ❌ Buttplug/intiface-desktop.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/neilmartin83-recipes/Buttplug/intiface-desktop.pkg.recipe
Processing repos/neilmartin83-recipes/Buttplug/intiface-desktop.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\.dmg$',
           'github_repo': 'intiface/intiface-desktop'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex '.*\.dmg$' among asset(s): intiface-desktop-19.0.0-linux-x64.tar.gz, intiface-desktop-19.0.0-linux-x86_64.AppImage, intiface-desktop-19.0.0-mac.dmg, intiface-desktop-19.0.0-mac.dmg.blockmap, intiface-desktop-19.0.0-mac.zip, intiface-desktop-19.0.0-win.exe, intiface-desktop-19.0.0-win.exe.blockmap, latest-linux.yml, latest-mac.yml, latest.yml
GitHubReleasesInfoProvider: Selected asset 'intiface-desktop-19.0.0-mac.dmg' from release 'Intiface Desktop Release v19'
{'Output': {'release_notes': '\r\n'
                             '\r\n'
                             '## Changes:\r\n'
                             '\r\n'
                             '* 4d5d06bd41faf7757e21ba79ee73e090da284983 '
                             'chore: v19 Version updates for subpackages.\r\n'
                             '* 9d7d4765ada34b22dd0e65223c448fe778d20f2e doc: '
                             'Update CHANGELOG/Package Version/Front page for '
                             'v19\r\n'
                             '* e83cb6009452171c6637af6b7c35dc2779aafda1 '
                             'chore: Reword websocket options, add better port '
                             'setting checking\r\n'
                             '* 069a19f350aeb1b692af08017addc89f503fb0f9 fix: '
                             'Change vee-validate plugin config for correct '
                             'rules\r\n'
                             '* 719657eff29a7b02028940b30904b2a1f06a4523 fix: '
                             'Fix parsing of incoming delimited protobuf '
                             'messages\r\n'
                             '\r\n'
                             'This list of changes was [auto '
                             'generated](https://dev.azure.com/nplabs/buttplug/_build/results?buildId=1255&view=logs).',
            'url': 'https://github.com/intiface/intiface-desktop/releases/download/v19.0.0/intiface-desktop-19.0.0-mac.dmg',
            'version': '19.0.0'}}
URLDownloader
{'Input': {'filename': 'intiface-desktop-19.0.0.dmg',
           'url': 'https://github.com/intiface/intiface-desktop/releases/download/v19.0.0/intiface-desktop-19.0.0-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.intiface-desktop/downloads/intiface-desktop-19.0.0.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.intiface-desktop/downloads/intiface-desktop-19.0.0.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.intiface-desktop/downloads/intiface-desktop-19.0.0.dmg/intiface-desktop.app',
           'requirement': 'identifier "com.nonpolynomiallabs.intiface-desktop" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'MSRA4LCTEZ'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.intiface-desktop/downloads/intiface-desktop-19.0.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.9M1kKS/intiface-desktop.app: code object is not signed at all
CodeSignatureVerifier: In architecture: x86_64
Receipt written to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.intiface-desktop/receipts/intiface-desktop.pkg-receipt-20210213-231225.plist

The following recipes failed:
    repos/neilmartin83-recipes/Buttplug/intiface-desktop.pkg.recipe
        Error in com.github.neilmartin83.pkg.intiface-desktop: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

Nothing downloaded, packaged or imported.
```

## ✅ Erik Burgland/ProfileCreator.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/neilmartin83-recipes/Erik\ Burgland/ProfileCreator.pkg.recipe
Processing repos/neilmartin83-recipes/Erik Burgland/ProfileCreator.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'ProfileCreator/ProfileCreator',
           'include_prereleases': 'true'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'ProfileCreator_v0.3.2-201907171032-beta.dmg' from release 'ProfileCreator 0.3.2'
{'Output': {'release_notes': 'Please report any bugs, feature requests or '
                             'suggestions as an issue to this repository.\r\n'
                             '\r\n'
                             '## Alternate Downloads\r\n'
                             '\r\n'
                             "If the downloaded .dmg doesn't open correctly "
                             'for you, please try one of the alternative '
                             'downloads provided.\r\n'
                             '\r\n'
                             '## ProfileCreator Wiki\r\n'
                             '\r\n'
                             'Remeber that the ProfileCreator '
                             '[wiki](https://github.com/erikberglund/ProfileCreator/wiki) '
                             'is continuously updated with information about '
                             'the application and the included payloats.\r\n'
                             '\r\n'
                             '## New Features\r\n'
                             '\r\n'
                             '### Open Source\r\n'
                             '\r\n'
                             'ProfileCreator is now Open Source under the GNU '
                             'General Public License v3.0.\r\n'
                             '\r\n'
                             'I write about this and the reasons why I have to '
                             'stop developing this application in a blog post '
                             'here: '
                             'https://erikberglund.github.io/2019/Profile_Creator_Open_Source/\r\n'
                             '\r\n'
                             '### Ability to reorder TableView rows.\r\n'
                             '\r\n'
                             "It's now possible to reorder TableView rows and "
                             'to add rows directly below the selected row.\r\n'
                             '\r\n'
                             '## New Payloads\r\n'
                             '\r\n'
                             '- edu.psu.macoslaps (macOS) (Added by '
                             '@erikberglund)\r\n'
                             '- com.apple.iWork.Numbers (macOS) (Added by '
                             '@tom.case)\r\n'
                             '- com.apple.iWork.Keynote (macOS) (Added by '
                             '@tom.case)\r\n'
                             '- com.apple.iWork.Pages (macOS) (Added by '
                             '@tom.case)\r\n'
                             '- com.apple.iTunes (macOS) (Added by '
                             '@tom.case)\r\n'
                             '- com.apple.iBooksX (macOS) (Added by '
                             '@tom.case)\r\n'
                             '\r\n'
                             '## Updated Payloads\r\n'
                             '\r\n'
                             '### com.microsoft.rdc.macos\r\n'
                             '\r\n'
                             '- @erikberglund added '
                             '`ClientSettings.EnforceCredSSPSupport`\r\n'
                             '\r\n'
                             '### com.apple.coreservices.uiagent\r\n'
                             '\r\n'
                             '- @erikberglund and @apizz fixed a typo on the '
                             'key `CSUIDisable32BitWarnings` \r\n'
                             '\r\n'
                             '### '
                             'com.apple.TCC.configuration-profile-policy\r\n'
                             '\r\n'
                             '- @erikberglund added the new TCC keys for '
                             '10.15.\r\n'
                             '\r\n'
                             '### com.apple.Safari\r\n'
                             '\r\n'
                             '- @tom.case added `CanPromptForNotifications`, '
                             '`EnableExtensions`, '
                             '`DidDisableIndividualExtensionsAfterRemovingOnOffSwitchIfNecessary`.\r\n'
                             '\r\n'
                             '### com.apple.smartcard\r\n'
                             '\r\n'
                             '- @AndrewWCarson added `tokenRemovalAction`. \r\n'
                             '\r\n'
                             '### ManagedInstall\r\n'
                             '\r\n'
                             '- @apizz added `LicenseInfoURL`, \r\n'
                             '\r\n'
                             '## Bug Fixes\r\n'
                             '\r\n'
                             '- Fixed issue...\r\n'
                             '\r\n'
                             '## Contribute\r\n'
                             '\r\n'
                             'If you wish to contribute to this project, the '
                             'following things are a good starting point:\r\n'
                             '\r\n'
                             '- Test and report bugs or incorrect behavior '
                             'both in the UI and in the exported profiles.\r\n'
                             '- Language and spelling errors. (English is not '
                             'my native language).\r\n'
                             '- Missing payloads or payload keys. (Contribute '
                             'to the ProfileManifests repository to improve '
                             'the manifests used to define all payloads, keys '
                             'and their interactions.)\r\n'
                             '- Add feature requests or suggestions by opening '
                             'an issue in this repository.\r\n',
            'url': 'https://github.com/ProfileCreator/ProfileCreator/releases/download/v0.3.2/ProfileCreator_v0.3.2-201907171032-beta.dmg',
            'version': '0.3.2'}}
URLDownloader
{'Input': {'filename': 'ProfileCreator-0.3.2.dmg',
           'url': 'https://github.com/ProfileCreator/ProfileCreator/releases/download/v0.3.2/ProfileCreator_v0.3.2-201907171032-beta.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.ProfileCreator/downloads/ProfileCreator-0.3.2.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.ProfileCreator/downloads/ProfileCreator-0.3.2.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.ProfileCreator/downloads/ProfileCreator-0.3.2.dmg/ProfileCreator.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.github.erikberglund.ProfileCreator" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'Y7QFC8672N)',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.ProfileCreator/downloads/ProfileCreator-0.3.2.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.8N3H9z/ProfileCreator.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.8N3H9z/ProfileCreator.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.8N3H9z/ProfileCreator.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
com.github.homebysix.VersionSplitter/VersionSplitter
{'Input': {'split_on': '-beta', 'version': '0.3.2'}}
VersionSplitter: Split version: 0.3.2
{'Output': {'version': '0.3.2'}}
AppPkgCreator
{'Input': {'version': '0.3.2'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.ProfileCreator/downloads/ProfileCreator-0.3.2.dmg
AppPkgCreator: Using path '/private/tmp/dmg.PCUSJi/ProfileCreator.app' matched from globbed '/private/tmp/dmg.PCUSJi/*.app'.
AppPkgCreator: BundleID: com.github.erikberglund.ProfileCreator
AppPkgCreator: Copied /private/tmp/dmg.PCUSJi/ProfileCreator.app to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.ProfileCreator/payload/Applications/ProfileCreator.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.github.erikberglund.ProfileCreator',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.ProfileCreator/ProfileCreator-0.3.2.pkg',
                                                        'version': '0.3.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '0.3.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.ProfileCreator/receipts/ProfileCreator.pkg-receipt-20210213-231236.plist

The following packages were built:
    Identifier                              Version  Pkg Path                                                                                                  
    ----------                              -------  --------                                                                                                  
    com.github.erikberglund.ProfileCreator  0.3.2    ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.ProfileCreator/ProfileCreator-0.3.2.pkg  
```

## ✅ Frederik Berlaen/DrawBot.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/neilmartin83-recipes/Frederik\ Berlaen/DrawBot.pkg.recipe
Processing repos/neilmartin83-recipes/Frederik Berlaen/DrawBot.pkg.recipe...
URLDownloader
{'Input': {'filename': 'DrawBot.dmg',
           'url': 'https://github.com/typemytype/drawbot/releases/latest/download/DrawBot.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/downloads/DrawBot.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/downloads/DrawBot.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/downloads/DrawBot.dmg/DrawBot.app',
           'requirement': 'identifier "com.drawbot" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = NNVFASZ82V'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/downloads/DrawBot.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.CspUN4/DrawBot.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.CspUN4/DrawBot.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.CspUN4/DrawBot.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/downloads/DrawBot.dmg/DrawBot.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/downloads/DrawBot.dmg
Versioner: Found version 3.126 in file /private/tmp/dmg.21o7LM/DrawBot.app/Contents/Info.plist
{'Output': {'version': '3.126'}}
AppPkgCreator
{'Input': {'version': '3.126'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/downloads/DrawBot.dmg
AppPkgCreator: Using path '/private/tmp/dmg.0FHhIs/DrawBot.app' matched from globbed '/private/tmp/dmg.0FHhIs/*.app'.
AppPkgCreator: BundleID: com.drawbot
AppPkgCreator: Copied /private/tmp/dmg.0FHhIs/DrawBot.app to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/payload/Applications/DrawBot.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.drawbot',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/DrawBot-3.126.pkg',
                                                        'version': '3.126'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.126'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/receipts/DrawBot.pkg-receipt-20210213-231304.plist

The following packages were built:
    Identifier   Version  Pkg Path                                                                                    
    ----------   -------  --------                                                                                    
    com.drawbot  3.126    ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.DrawBot/DrawBot-3.126.pkg  
```

## ✅ Hasselblad/Phocus.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/neilmartin83-recipes/Hasselblad/Phocus.pkg.recipe
Processing repos/neilmartin83-recipes/Hasselblad/Phocus.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'https:\\/\\/cdn\\.hasselblad\\.com\\/software\\/Phocus-for-Mac\\/\\S*\\/Phocus-\\S*\\.dmg',
           'url': 'https://api.hasselblad.com/products/downloads/133'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://cdn.hasselblad.com/software/Phocus-for-Mac/3.5.4/Phocus-3.5.4.dmg
{'Output': {'match': 'https://cdn.hasselblad.com/software/Phocus-for-Mac/3.5.4/Phocus-3.5.4.dmg'}}
URLDownloader
{'Input': {'filename': 'Phocus.dmg',
           'url': 'https://cdn.hasselblad.com/software/Phocus-for-Mac/3.5.4/Phocus-3.5.4.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/downloads/Phocus.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/downloads/Phocus.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/downloads/Phocus.dmg/Phocus.app',
           'requirement': 'anchor apple generic and identifier '
                          '"dk.hasselblad.phocus" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "56UFF38UTM")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/downloads/Phocus.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.K5HPDv/Phocus.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.K5HPDv/Phocus.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.K5HPDv/Phocus.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/downloads/Phocus.dmg/Phocus.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/downloads/Phocus.dmg
Versioner: Found version 3.5.4 in file /private/tmp/dmg.Jtbtj1/Phocus.app/Contents/Info.plist
{'Output': {'version': '3.5.4'}}
AppPkgCreator
{'Input': {'version': '3.5.4'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/downloads/Phocus.dmg
AppPkgCreator: Using path '/private/tmp/dmg.ttJnvk/Phocus.app' matched from globbed '/private/tmp/dmg.ttJnvk/*.app'.
AppPkgCreator: BundleID: dk.hasselblad.phocus
AppPkgCreator: Copied /private/tmp/dmg.ttJnvk/Phocus.app to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/payload/Applications/Phocus.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'dk.hasselblad.phocus',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/Phocus-3.5.4.pkg',
                                                        'version': '3.5.4'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.5.4'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/receipts/Phocus.pkg-receipt-20210213-231327.plist

The following packages were built:
    Identifier            Version  Pkg Path                                                                                  
    ----------            -------  --------                                                                                  
    dk.hasselblad.phocus  3.5.4    ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Phocus/Phocus-3.5.4.pkg  
```

## ✅ Mounty for NTFS/Mounty.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/neilmartin83-recipes/Mounty\ for\ NTFS/Mounty.pkg.recipe
Processing repos/neilmartin83-recipes/Mounty for NTFS/Mounty.pkg.recipe...
URLDownloader
{'Input': {'url': 'https://mounty.app/releases/Mounty.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Mounty/downloads/Mounty.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Mounty/downloads/Mounty.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Mounty/downloads/Mounty.dmg/Mounty.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.cu4uc.mounty" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = SG6DU88C24)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Mounty/downloads/Mounty.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.zSZD99/Mounty.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.zSZD99/Mounty.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.zSZD99/Mounty.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Mounty/downloads/Mounty.dmg
AppPkgCreator: Using path '/private/tmp/dmg.5OzXYv/Mounty.app' matched from globbed '/private/tmp/dmg.5OzXYv/*.app'.
AppPkgCreator: Version: 1.12
AppPkgCreator: BundleID: com.cu4uc.mounty
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Mounty/Mounty-1.12.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '1.12'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.Mounty/receipts/Mounty.pkg-receipt-20210213-231331.plist

Nothing downloaded, packaged or imported.
```

## ✅ Native Instruments/NativeAccess.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/neilmartin83-recipes/Native\ Instruments/NativeAccess.pkg.recipe
Processing repos/neilmartin83-recipes/Native Instruments/NativeAccess.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Native_Instruments_Native_Access.dmg',
           'url': 'https://www.native-instruments.com/fileadmin/downloads/Native_Access_Installer.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/downloads/Native_Instruments_Native_Access.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/downloads/Native_Instruments_Native_Access.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/downloads/Native_Instruments_Native_Access.dmg/Native '
                         'Access.app',
           'requirement': 'identifier "com.native-instruments.Native Access" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"83K5EG6Z9V"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/downloads/Native_Instruments_Native_Access.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.IruaOi/Native Access.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.IruaOi/Native Access.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.IruaOi/Native Access.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/downloads/Native_Instruments_Native_Access.dmg/Native '
                               'Access.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/downloads/Native_Instruments_Native_Access.dmg
Versioner: Found version 1.13.3.136 in file /private/tmp/dmg.n8aaG4/Native Access.app/Contents/Info.plist
{'Output': {'version': '1.13.3.136'}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/Native_Instruments_Native_Access'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/Native_Instruments_Native_Access
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/Native_Instruments_Native_Access/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/Native_Instruments_Native_Access/Applications/Native '
                               'Access.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/downloads/Native_Instruments_Native_Access.dmg/Native '
                          'Access.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/downloads/Native_Instruments_Native_Access.dmg, dmg: .dmg/, dmg_source_path: Native Access.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/downloads/Native_Instruments_Native_Access.dmg
Copier: Copied /private/tmp/dmg.MhkDkg/Native Access.app to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/Native_Instruments_Native_Access/Applications/Native Access.app
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'com.native-instruments.nativeaccess.pkg',
                           'options': 'purge_ds_store',
                           'pkgdir': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess',
                           'scripts': 'NativeAccess_Scripts'}}}
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'com.native-instruments.nativeaccess.pkg',
                                                    'pkg_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/Native_Instruments_Native_Access_1.13.3.136.pkg',
                                                    'version': '1.13.3.136'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/Native_Instruments_Native_Access_1.13.3.136.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/receipts/NativeAccess.pkg-receipt-20210213-231405.plist

The following packages were built:
    Identifier                               Version     Pkg Path                                                                                                                       
    ----------                               -------     --------                                                                                                                       
    com.native-instruments.nativeaccess.pkg  1.13.3.136  ~/Library/AutoPkg/Cache/com.github.neilmartin83.pkg.NativeAccess/Native_Instruments_Native_Access_1.13.3.136.pkg  
```

