### PR TITLE
Update RecipeBuilder.munki.recipe

### DIFF
--- a/RecipeBuilder/RecipeBuilder.munki.recipe
+++ b/RecipeBuilder/RecipeBuilder.munki.recipe
@@ -35,20 +35,42 @@
         <key>MinimumVersion</key>
         <string>0.5.0</string>
         <key>ParentRecipe</key>
-        <string>com.github.neilmartin83.pkg.RecipeBuilder</string>
+        <string>com.github.neilmartin83.download.RecipeBuilder</string>
         <key>Process</key>
         <array>
             <dict>
+                <key>Processor</key>
+                <string>DmgCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>dmg_root</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <key>dmg_path</key>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>MunkiImporter</string>
                 <key>Arguments</key>
                 <dict>
                     <key>pkg_path</key>
-                    <string>%pkg_path%</string>
+                    <string>%dmg_path%</string>
                     <key>repo_subdirectory</key>
                     <string>%MUNKI_REPO_SUBDIR%</string>
                 </dict>
-                <key>Processor</key>
-                <string>MunkiImporter</string>
             </dict>
+			<dict>
+				<key>Processor</key>
+				<string>PathDeleter</string>
+				<key>Arguments</key>
+				<dict>
+					<key>path_list</key>
+					<array>
+						<string>%RECIPE_CACHE_DIR%/unpack</string>                   
+					</array>
+				</dict>
+			</dict>
         </array>
     </dict>
 </plist>


### PR DESCRIPTION
• Changes .munki to use .download as parent
• now creates an installs array of the .app on disk
• pathdeleter tidies up afterwards