### PR TITLE
Update RecipeBuilder.download.recipe

### DIFF
--- a/RecipeBuilder/RecipeBuilder.download.recipe
+++ b/RecipeBuilder/RecipeBuilder.download.recipe
@@ -58,7 +58,7 @@
                     <key>input_path</key>
                     <string>%RECIPE_CACHE_DIR%/unpack/RecipeBuilder.app</string>
                     <key>requirement</key>
-                    <string>anchor apple generic and identifier "se.dicom.RecipeBuilder" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "543LXU387V")</string>
+                    <string>anchor apple generic and identifier "se.mikaellofgren.RecipeBuilder" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = F489D96499)</string>
                 </dict>
                 <key>Processor</key>
                 <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Hi, @neilmartin83 

This PR contains an updated `requirement` for `CodeSignatureVerifier`

-vvv output:

```
autopkg run -vvv /Users/paul/Documents/GitHub/neilmartin83-recipes/RecipeBuilder/RecipeBuilder.download.recipe 
Processing /Users/paul/Documents/GitHub/neilmartin83-recipes/RecipeBuilder/RecipeBuilder.download.recipe...
WARNING: /Users/paul/Documents/GitHub/neilmartin83-recipes/RecipeBuilder/RecipeBuilder.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.3.1',
 'GITHUB_REPO': 'mikaellofgren/RecipeBuilder',
 'GIT_PATH': '/Applications/Xcode.app/Contents/Developer/usr/bin/git',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'RecipeBuilder',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder',
 'RECIPE_DIR': '/Users/paul/Documents/GitHub/neilmartin83-recipes/RecipeBuilder',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/paul/Documents/GitHub/neilmartin83-recipes/RecipeBuilder/RecipeBuilder.download.recipe',
 'RECIPE_REPOS': {},
 'RECIPE_REPO_DIR': '/Users/Shared/munki_repo',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes'],
 'verbose': 3}
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'mikaellofgren/RecipeBuilder'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Selected asset 'RecipeBuilder.app.zip' from release '1.04'
{'Output': {'release_notes': "- Added support for 'jamf' processors and recipe "
                             'format\r\n'
                             'https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors\r\n'
                             '- Added Verify Recipes files (at Options) that '
                             'will check for:\r\n'
                             'Duplicated identifiers\r\n'
                             'Parent Identifiers is not the same as '
                             'Identifier \r\n'
                             'MinimumVersion matches processor required '
                             'version.\r\n'
                             'For Yaml recipes will only check duplicated '
                             'Identifiers and Parent and MinimumVersion is '
                             '2.3.\r\n'
                             'Deprecated Processors\r\n'
                             'EndOfCheckPhase is after URLDownloader\r\n'
                             '- Fixed button view\r\n'
                             '- Added Visual Studio Code to open with external '
                             'editor\r\n'
                             '- Universal build\r\n'
                             '\r\n'
                             'Verify Recipes files is inspired by homebysix '
                             'precommit:\r\n'
                             'https://github.com/homebysix/pre-commit-macadmin/blob/main/pre_commit_hooks/check_autopkg_recipes.py',
            'url': 'https://github.com/mikaellofgren/RecipeBuilder/releases/download/1.04/RecipeBuilder.app.zip',
            'version': '1.04'}}
URLDownloader
{'Input': {'filename': 'RecipeBuilder.zip',
           'url': 'https://github.com/mikaellofgren/RecipeBuilder/releases/download/1.04/RecipeBuilder.app.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 24 Apr 2022 15:13:31 GMT
URLDownloader: Storing new ETag header: "0x8DA2604FE1658CC"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/downloads/RecipeBuilder.zip
{'Output': {'download_changed': True,
            'etag': '"0x8DA2604FE1658CC"',
            'last_modified': 'Sun, 24 Apr 2022 15:13:31 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/downloads/RecipeBuilder.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/downloads/RecipeBuilder.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/downloads/RecipeBuilder.zip',
           'destination_path': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/unpack',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename RecipeBuilder.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/downloads/RecipeBuilder.zip to /Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/unpack
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/unpack/RecipeBuilder.app',
           'requirement': 'anchor apple generic and identifier '
                          '"se.mikaellofgren.RecipeBuilder" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = F489D96499)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/unpack/RecipeBuilder.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/unpack/RecipeBuilder.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/unpack/RecipeBuilder.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
{'AUTOPKG_VERSION': '2.3.1',
 'CHECK_FILESIZE_ONLY': False,
 'CURL_PATH': '/usr/bin/curl',
 'GITHUB_REPO': 'mikaellofgren/RecipeBuilder',
 'GITHUB_TOKEN_PATH': '~/.autopkg_gh_token',
 'GITHUB_URL': 'https://api.github.com',
 'GIT_PATH': '/Applications/Xcode.app/Contents/Developer/usr/bin/git',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'RecipeBuilder',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder',
 'RECIPE_DIR': '/Users/paul/Documents/GitHub/neilmartin83-recipes/RecipeBuilder',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/paul/Documents/GitHub/neilmartin83-recipes/RecipeBuilder/RecipeBuilder.download.recipe',
 'RECIPE_REPOS': {},
 'RECIPE_REPO_DIR': '/Users/Shared/munki_repo',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes'],
 'USE_PYTHON_NATIVE_EXTRACTOR': False,
 'archive_path': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/downloads/RecipeBuilder.zip',
 'destination_path': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/unpack',
 'download_changed': True,
 'etag': '"0x8DA2604FE1658CC"',
 'filename': 'RecipeBuilder.zip',
 'github_repo': 'mikaellofgren/RecipeBuilder',
 'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/unpack/RecipeBuilder.app',
 'last_modified': 'Sun, 24 Apr 2022 15:13:31 GMT',
 'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/downloads/RecipeBuilder.zip',
 'prefetch_filename': False,
 'purge_destination': True,
 'release_notes': "- Added support for 'jamf' processors and recipe format\r\n"
                  'https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors\r\n'
                  '- Added Verify Recipes files (at Options) that will check '
                  'for:\r\n'
                  'Duplicated identifiers\r\n'
                  'Parent Identifiers is not the same as Identifier \r\n'
                  'MinimumVersion matches processor required version.\r\n'
                  'For Yaml recipes will only check duplicated Identifiers and '
                  'Parent and MinimumVersion is 2.3.\r\n'
                  'Deprecated Processors\r\n'
                  'EndOfCheckPhase is after URLDownloader\r\n'
                  '- Fixed button view\r\n'
                  '- Added Visual Studio Code to open with external editor\r\n'
                  '- Universal build\r\n'
                  '\r\n'
                  'Verify Recipes files is inspired by homebysix precommit:\r\n'
                  'https://github.com/homebysix/pre-commit-macadmin/blob/main/pre_commit_hooks/check_autopkg_recipes.py',
 'requirement': 'anchor apple generic and identifier '
                '"se.mikaellofgren.RecipeBuilder" and (certificate '
                'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or '
                'certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ '
                'and certificate leaf[field.1.2.840.113635.100.6.1.13] /* '
                'exists */ and certificate leaf[subject.OU] = F489D96499)',
 'url': 'https://github.com/mikaellofgren/RecipeBuilder/releases/download/1.04/RecipeBuilder.app.zip',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/downloads/RecipeBuilder.zip'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 3,
 'version': '1.04'}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/receipts/RecipeBuilder.download-receipt-20220429-111229.plist

The following new items were downloaded:
    Download Path                                                                                                 
    -------------                                                                                                 
    /Users/paul/Library/AutoPkg/Cache/com.github.neilmartin83.download.RecipeBuilder/downloads/RecipeBuilder.zip  
```