### PR TITLE
Update ProfileCreator.download.recipe

### DIFF
--- a/Erik Berglund/ProfileCreator.download.recipe
+++ b/Erik Berglund/ProfileCreator.download.recipe
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
+				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -40,19 +40,6 @@
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/Applications/</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @neilmartin83 

The ProfileCreator download recipe is currently failing due the file format changing from zip file to a dmg
```
Unarchiver: Error: Unarchiving /Users/sadmin/Library/AutoPkg/Cache/local.definition.ProfileCreator/downloads/ProfileCreator-0.3.6.zip with ditto failed: ditto: Couldn't read PKZip signature
```

This PR changes updates to reflect. 

Output from a successful -v run
```
autopkg run -v ProfileCreator.download.recipe
**load_recipe time: 0.0002900830004364252
Processing ProfileCreator.download.recipe...
WARNING: ProfileCreator.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Selected asset 'ProfileCreator-0.3.6.dmg' from tag '0.3.6' at url https://github.com/ProfileCreator/ProfileCreator/releases/download/0.3.6/ProfileCreator-0.3.6.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 23 Dec 2024 23:41:21 GMT
URLDownloader: Storing new ETag header: "0x8DD23AB4E367CA5"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.neilmartin83.download.ProfileCreator/downloads/ProfileCreator-0.3.6.dmg
EndOfCheckPhase
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.neilmartin83.download.ProfileCreator/receipts/ProfileCreator.download-receipt-20241224-125115.plist

The following new items were downloaded:
    Download Path                                                                                                                
    -------------                                                                                                                
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.neilmartin83.download.ProfileCreator/downloads/ProfileCreator-0.3.6.dmg 
```