### PR TITLE
Update ProfileCreator.download - Set include_prereleases to be an input variable

### DIFF
--- a/Erik Berglund/ProfileCreator.download.recipe
+++ b/Erik Berglund/ProfileCreator.download.recipe
@@ -3,7 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of ProfileCreator.</string>
+	<string>Downloads the latest version of ProfileCreator.
+
+Set PRERELEASE to a non-empty string to download prereleases, either
+via Input in an override or via the -k option,
+i.e.: `-k PRERELEASE=yes</string>
 	<key>Identifier</key>
 	<string>com.github.neilmartin83.download.ProfileCreator</string>
 	<key>Input</key>
@@ -12,6 +16,8 @@
 		<string>ProfileCreator/ProfileCreator</string>
 		<key>NAME</key>
 		<string>ProfileCreator</string>
+		<key>PRERELEASE</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -23,7 +29,7 @@
 				<key>github_repo</key>
 				<string>%GITHUB_REPO%</string>
 				<key>include_prereleases</key>
-				<string>true</string>
+				<string>%PRERELEASE%</string>
 			</dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
Hi, @neilmartin83 

This PR sets the `include_prereleases` key to be an input variable defaulting to false. 

```
autopkg run -v ProfileCreator.download.recipe
**load_recipe time: 0.00029670799267478287
Processing ProfileCreator.download.recipe...
WARNING: ProfileCreator.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Selected asset 'ProfileCreator-v0.3.3-UNSIGNED.zip' from tag 'v0.3.3' at url https://github.com/ProfileCreator/ProfileCreator/releases/download/v0.3.3/ProfileCreator-v0.3.3-UNSIGNED.zip
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 08 Dec 2021 02:17:54 GMT
URLDownloader: Storing new ETag header: "0x8D9B9F0F1BA06A7"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.neilmartin83.download.ProfileCreator/downloads/ProfileCreator-0.3.3.dmg
EndOfCheckPhase
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.neilmartin83.download.ProfileCreator/receipts/ProfileCreator.download-receipt-20250107-104834.plist

The following new items were downloaded:
    Download Path                                                                                                                
    -------------                                                                                                                
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.neilmartin83.download.ProfileCreator/downloads/ProfileCreator-0.3.3.dmg 
```

