### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Adobe/AdobeExpiryCheck.pkg.recipe.yaml
+++ b/Adobe/AdobeExpiryCheck.pkg.recipe.yaml
@@ -35,7 +35,6 @@ Process:
         path: usr
         user: root
       id: com.adobe.AdobeExpiryCheck
-      options: purge_ds_store
       pkgdir: '%RECIPE_CACHE_DIR%'
       pkgname: '%NAME%-%version%'
       version: '%version%'

--- a/Adobe/AdobeUninstallUnauthorizedVersions.pkg.recipe.yaml
+++ b/Adobe/AdobeUninstallUnauthorizedVersions.pkg.recipe.yaml
@@ -31,7 +31,6 @@ Process:
         path: private
         user: root
       id: com.adobe.AdobeUninstallUnauthorizedVersions
-      options: purge_ds_store
       pkgdir: '%RECIPE_CACHE_DIR%'
       pkgname: '%NAME%'
       scripts: AdobeUninstallUnauthorizedVersions_Scripts

--- a/Astute/Astute Manager.pkg.recipe.yaml
+++ b/Astute/Astute Manager.pkg.recipe.yaml
@@ -30,7 +30,6 @@ Process:
         path: Applications
         user: root
       id: com.astutegraphics.astutemanager.pkg
-      options: purge_ds_store
       pkgdir: '%RECIPE_CACHE_DIR%'
       pkgname: '%NAME%-%version%'
       scripts: package_scripts

--- a/Belight Software/LabelsandAddresses.pkg.recipe.yaml
+++ b/Belight Software/LabelsandAddresses.pkg.recipe.yaml
@@ -31,6 +31,5 @@ Process:
         path: Applications
         user: root
       id: '%BUNDLE_ID%'
-      options: purge_ds_store
       pkgdir: '%RECIPE_CACHE_DIR%'
       pkgname: '%NAME%-%version%'

--- a/LAPS-for-macOS/LAPS-for-macOS.pkg.recipe.yaml
+++ b/LAPS-for-macOS/LAPS-for-macOS.pkg.recipe.yaml
@@ -25,6 +25,5 @@ Process:
         path: Applications
         user: root
       id: com.github.joshua-d-miller.LAPS-for-macOS
-      options: purge_ds_store
       pkgdir: '%RECIPE_CACHE_DIR%'
       pkgname: '%NAME%-%version%'

--- a/Mozilla/FirefoxPolicies.pkg.recipe.yaml
+++ b/Mozilla/FirefoxPolicies.pkg.recipe.yaml
@@ -59,6 +59,5 @@ Process:
         path: Applications
         user: root
       id: '%PKG_ID%'
-      options: purge_ds_store
       pkgdir: '%RECIPE_CACHE_DIR%'
       pkgname: '%NAME%_%ORG_NAME%-%version%'

--- a/Native Instruments/NativeAccess.pkg.recipe.yaml
+++ b/Native Instruments/NativeAccess.pkg.recipe.yaml
@@ -26,7 +26,6 @@ Process:
         path: Applications
         user: root
       id: com.native-instruments.nativeaccess.pkg
-      options: purge_ds_store
       pkgdir: '%RECIPE_CACHE_DIR%'
       scripts: NativeAccess_Scripts
     pkgname: '%NAME%_%version%'

--- a/Zotero/Zotero.pkg.recipe.yaml
+++ b/Zotero/Zotero.pkg.recipe.yaml
@@ -30,6 +30,5 @@ Process:
         path: Applications
         user: root
       id: org.zotero.pkg
-      options: purge_ds_store
       pkgdir: '%RECIPE_CACHE_DIR%'
       pkgname: '%NAME%_%version%'


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._