### PR TITLE
Fix pattern in FileFinder to match .pkg files

### DIFF
--- a/Tenable/Nessus Agent.download.recipe.yaml
+++ b/Tenable/Nessus Agent.download.recipe.yaml
@@ -18,7 +18,7 @@ Process:
 
 - Processor: FileFinder
   Arguments:
-    pattern: '%pathname%/.*.pkg'
+    pattern: '%pathname%/*.pkg'
 
 - Processor: CodeSignatureVerifier
   Arguments:


### PR DESCRIPTION
Looks like Tenable have changed the pkg path in the dmg to no longer have the period prefix.