### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Tenable/Nessus Agent.download.recipe.yaml
+++ b/Tenable/Nessus Agent.download.recipe.yaml
@@ -16,6 +16,8 @@ Process:
     filename: '%NAME%-%version%.dmg'
     url: https://www.tenable.com/downloads/api/v1/public/pages/nessus-agents/downloads/%id%/download?i_agree_to_tenable_license_agreement=true
 
+- Processor: EndOfCheckPhase
+
 - Processor: FileFinder
   Arguments:
     pattern: '%pathname%/*.pkg'

--- a/VMPK/VMPK.download.recipe.yaml
+++ b/VMPK/VMPK.download.recipe.yaml
@@ -14,3 +14,5 @@ Process:
 - Processor: URLDownloader
   Arguments:
     filename: '%NAME%.dmg'
+
+- Processor: EndOfCheckPhase


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.